### PR TITLE
Make install vs.cnf world readable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,12 +77,12 @@ install(CODE "
         file(INSTALL \"${CMAKE_SOURCE_DIR}/vs.cnf\"
             DESTINATION ${CMAKE_INSTALL_PREFIX}/${InstallSuffix}
             RENAME \"vs.cnf.new\"
-            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
+            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
         )
     else()
         file(INSTALL \"${CMAKE_SOURCE_DIR}/vs.cnf\"
             DESTINATION ${CMAKE_INSTALL_PREFIX}/${InstallSuffix}
-            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
+            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
         )
     endif(EXISTS \"${CMAKE_INSTALL_PREFIX}/${InstallSuffix}/vs.cnf\")
 ")


### PR DESCRIPTION
Since SQLlite doesn't need any authentication credentials to be stored in this file, it can be world readable. This simplifies using a single shared read-only install across multiple groups/users.